### PR TITLE
Fix GelfHandlerFactory to be compatible with ServiceManager v3

### DIFF
--- a/src/Handler/Factory/GelfHandlerFactory.php
+++ b/src/Handler/Factory/GelfHandlerFactory.php
@@ -19,13 +19,21 @@ class GelfHandlerFactory implements FactoryInterface
     /**
      * @param array $options
      */
-    public function __construct(array $options)
+    public function __construct(array $options = [])
     {
+        // Zend ServiceManager v2 allows factory creationOptions
         $this->options = $options;
     }
 
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
+        /**
+         * Avoid a BC break; Zend ServiceManager v2 will pass the options via the constructor, v3 to the __invoke()
+         */
+        if (null !== $options) {
+            $this->options = array_merge($this->options, $options);
+        }
+
         if (!isset($this->options['host'])) {
             throw new Exception\RuntimeException('Gelf handler needs a host value');
         }

--- a/tests/Handler/Factory/GelfHandlerFactoryTest.php
+++ b/tests/Handler/Factory/GelfHandlerFactoryTest.php
@@ -21,6 +21,23 @@ class GelfHandlerFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(GelfHandler::class, $gelfHandler);
     }
 
+    public function testInstantiateGelfHandlerViaInvokeOptions()
+    {
+        $serviceLocator = $this->createMock(ServiceLocatorInterface::class);
+
+        $gelfHandlerFactory = new GelfHandlerFactory();
+        $gelfHandler = $gelfHandlerFactory->__invoke(
+            $serviceLocator,
+            GelfHandler::class,
+            [
+                'host' => 'domain.com',
+                'port' => 123,
+            ]
+        );
+
+        $this->assertInstanceOf(GelfHandler::class, $gelfHandler);
+    }
+
     /**
      * @expectedException \MonologModule\Exception\RuntimeException
      */


### PR DESCRIPTION
The GelfHandlerFactory is currently not compatible with version 3 of the ServiceManager because the options array in the constructor is mandatory. In v3 the options are passed via the `__invoke` method.

This fix made the constructor options optional (to be compatible with v2) and also allows the options to be passed via the `__invoke` method (v3). Afaik no BC breaks.
