### PR TITLE
Added factory code to add processors to specific handlers

### DIFF
--- a/src/Factory/LoggerFactory.php
+++ b/src/Factory/LoggerFactory.php
@@ -37,7 +37,13 @@ class LoggerFactory
 
         if (isset($config['handlers']) && is_array($config['handlers'])) {
             foreach ($config['handlers'] as $handler) {
-                $logger->pushHandler($this->createHandler($handler));
+                $newHandler = $this->createHandler($handler);
+                if (isset($handler['processors']) && is_array($handler['processors'])) {
+                    foreach ($handler['processors'] as $processor) {
+                        $newHandler->pushProcessor($this->createProcessor($processor));
+                    }
+                }
+                $logger->pushHandler($newHandler);
             }
         }
         if (isset($config['processors']) && is_array($config['processors'])) {

--- a/tests/Factory/LoggerFactoryTest.php
+++ b/tests/Factory/LoggerFactoryTest.php
@@ -303,4 +303,43 @@ class LoggerFactoryTest extends TestCase
         ];
         $factory->create($config);
     }
+    
+    public function testCreateLoggerWithHandlerAndProcessor()
+    {
+        $factory = new LoggerFactory();
+
+        $serviceLocator = $this->createMock(ServiceLocatorInterface::class);
+        $serviceLocator
+            ->expects($this->at(0))
+            ->method('has')
+            ->with(HandlerPluginManager::class)
+            ->will($this->returnValue(true));
+        $serviceLocator
+            ->expects($this->at(1))
+            ->method('get')
+            ->with(HandlerPluginManager::class)
+            ->will($this->returnValue(null));
+            
+        $factory->setContainer($serviceLocator);
+
+        $config = [
+            'name' => 'foo',
+            'handlers' => [
+                'default' => [
+                    'name'      => TestHandler::class,
+                    'processors' => [
+                        TagProcessor::class,
+                    ],
+                ],
+            ],
+        ];
+        $logger = $factory->create($config);
+        $this->assertInstanceOf('Monolog\Logger', $logger);
+
+        $handler = $logger->popHandler();
+        $this->assertInstanceOf(TestHandler::class, $handler);
+
+        $processor = $handler->popProcessor();
+        $this->assertInstanceOf(TagProcessor::class, $processor);
+    }
 }


### PR DESCRIPTION
Processors are also able to be added to handlers ( see https://github.com/Seldaek/monolog/blob/1.x/src/Monolog/Handler/HandlerInterface.php#L67 ) - the factory was missing support for this so it's been added below.